### PR TITLE
Fix crash when inserting invalid integer into DATETIME column with DuckDB engine

### DIFF
--- a/mysql-test/suite/duckdb/r/duckdb_invalid_datetime.result
+++ b/mysql-test/suite/duckdb/r/duckdb_invalid_datetime.result
@@ -1,0 +1,157 @@
+#
+# Setup
+#
+# =========================================================
+# Scenario 1: INSERT with invalid integer (57399)
+#   This is the original crash case from GitHub issue#131.
+# =========================================================
+DROP TABLE IF EXISTS t_duckdb, t_innodb;
+CREATE TABLE t_duckdb (
+id INT NOT NULL AUTO_INCREMENT,
+col1 DATETIME NULL DEFAULT '2026-01-01 00:00:00',
+PRIMARY KEY (id)
+) ENGINE=DuckDB;
+CREATE TABLE t_innodb (
+id INT NOT NULL AUTO_INCREMENT,
+col1 DATETIME NULL DEFAULT '2026-01-01 00:00:00',
+PRIMARY KEY (id)
+) ENGINE=InnoDB;
+INSERT IGNORE INTO t_duckdb (id, col1) VALUES (1, 57399);
+Warnings:
+Warning	1265	Data truncated for column 'col1' at row 1
+INSERT IGNORE INTO t_innodb (id, col1) VALUES (1, 57399);
+Warnings:
+Warning	1265	Data truncated for column 'col1' at row 1
+INSERT INTO t_duckdb (id, col1) VALUES (2, 57399);
+ERROR 22007: Incorrect datetime value: '57399' for column 'col1' at row 1
+INSERT INTO t_innodb (id, col1) VALUES (2, 57399);
+ERROR 22007: Incorrect datetime value: '57399' for column 'col1' at row 1
+SET @saved_sql_mode = @@SESSION.sql_mode;
+SET sql_mode = '';
+INSERT INTO t_duckdb (id, col1) VALUES (2, 57399);
+Warnings:
+Warning	1265	Data truncated for column 'col1' at row 1
+INSERT INTO t_innodb (id, col1) VALUES (2, 57399);
+Warnings:
+Warning	1265	Data truncated for column 'col1' at row 1
+SET sql_mode = @saved_sql_mode;
+SELECT * FROM t_duckdb ORDER BY id;
+id	col1
+1	0000-00-00 00:00:00
+2	0000-00-00 00:00:00
+SELECT * FROM t_innodb ORDER BY id;
+id	col1
+1	0000-00-00 00:00:00
+2	0000-00-00 00:00:00
+include/assert.inc [Checksum is the same]
+# Scenario 1 PASSED: checksums match
+# ==================================================
+# Scenario 2: INSERT with various invalid integers
+# ==================================================
+DROP TABLE IF EXISTS t_duckdb, t_innodb;
+CREATE TABLE t_duckdb (
+id INT NOT NULL AUTO_INCREMENT,
+col1 DATETIME NULL DEFAULT '2026-01-01 00:00:00',
+PRIMARY KEY (id)
+) ENGINE=DuckDB;
+CREATE TABLE t_innodb (
+id INT NOT NULL AUTO_INCREMENT,
+col1 DATETIME NULL DEFAULT '2026-01-01 00:00:00',
+PRIMARY KEY (id)
+) ENGINE=InnoDB;
+INSERT IGNORE INTO t_duckdb (id, col1) VALUES
+(1, 0), (2, 99), (3, 101), (4, 57399), (5, 13320199), (6, -1);
+Warnings:
+Warning	1264	Out of range value for column 'col1' at row 1
+Warning	1265	Data truncated for column 'col1' at row 2
+Warning	1265	Data truncated for column 'col1' at row 4
+Warning	1265	Data truncated for column 'col1' at row 5
+Warning	1264	Out of range value for column 'col1' at row 6
+INSERT IGNORE INTO t_innodb (id, col1) VALUES
+(1, 0), (2, 99), (3, 101), (4, 57399), (5, 13320199), (6, -1);
+Warnings:
+Warning	1264	Out of range value for column 'col1' at row 1
+Warning	1265	Data truncated for column 'col1' at row 2
+Warning	1265	Data truncated for column 'col1' at row 4
+Warning	1265	Data truncated for column 'col1' at row 5
+Warning	1264	Out of range value for column 'col1' at row 6
+SELECT * FROM t_duckdb ORDER BY id;
+id	col1
+1	0000-00-00 00:00:00
+2	0000-00-00 00:00:00
+3	2000-01-01 00:00:00
+4	0000-00-00 00:00:00
+5	0000-00-00 00:00:00
+6	0000-00-00 00:00:00
+SELECT * FROM t_innodb ORDER BY id;
+id	col1
+1	0000-00-00 00:00:00
+2	0000-00-00 00:00:00
+3	2000-01-01 00:00:00
+4	0000-00-00 00:00:00
+5	0000-00-00 00:00:00
+6	0000-00-00 00:00:00
+include/assert.inc [Checksum is the same]
+# Scenario 2 PASSED: checksums match
+# =========================================================
+# Scenario 3: INSERT with mixing valid and invalid values
+# =========================================================
+DROP TABLE IF EXISTS t_duckdb, t_innodb;
+CREATE TABLE t_duckdb (
+id INT NOT NULL AUTO_INCREMENT,
+col1 DATETIME NULL DEFAULT '2026-01-01 00:00:00',
+PRIMARY KEY (id)
+) ENGINE=DuckDB;
+CREATE TABLE t_innodb (
+id INT NOT NULL AUTO_INCREMENT,
+col1 DATETIME NULL DEFAULT '2026-01-01 00:00:00',
+PRIMARY KEY (id)
+) ENGINE=InnoDB;
+INSERT IGNORE INTO t_duckdb (id, col1) VALUES
+(1, '2026-06-15 10:30:00'),
+(2, 57399),
+(3, '2020-01-01 00:00:00'),
+(4, 0),
+(5, 20240615103000),
+(6, NULL),
+(7, '0000-00-00 00:00:00');
+Warnings:
+Warning	1265	Data truncated for column 'col1' at row 2
+Warning	1264	Out of range value for column 'col1' at row 4
+Warning	1264	Out of range value for column 'col1' at row 7
+INSERT IGNORE INTO t_innodb (id, col1) VALUES
+(1, '2026-06-15 10:30:00'),
+(2, 57399),
+(3, '2020-01-01 00:00:00'),
+(4, 0),
+(5, 20240615103000),
+(6, NULL),
+(7, '0000-00-00 00:00:00');
+Warnings:
+Warning	1265	Data truncated for column 'col1' at row 2
+Warning	1264	Out of range value for column 'col1' at row 4
+Warning	1264	Out of range value for column 'col1' at row 7
+SELECT * FROM t_duckdb ORDER BY id;
+id	col1
+1	2026-06-15 10:30:00
+2	0000-00-00 00:00:00
+3	2020-01-01 00:00:00
+4	0000-00-00 00:00:00
+5	2024-06-15 10:30:00
+6	NULL
+7	0000-00-00 00:00:00
+SELECT * FROM t_innodb ORDER BY id;
+id	col1
+1	2026-06-15 10:30:00
+2	0000-00-00 00:00:00
+3	2020-01-01 00:00:00
+4	0000-00-00 00:00:00
+5	2024-06-15 10:30:00
+6	NULL
+7	0000-00-00 00:00:00
+include/assert.inc [Checksum is the same]
+# Scenario 3 PASSED: checksums match
+#
+# Cleanup
+#
+DROP TABLE t_duckdb, t_innodb;

--- a/mysql-test/suite/duckdb/t/duckdb_invalid_datetime.test
+++ b/mysql-test/suite/duckdb/t/duckdb_invalid_datetime.test
@@ -1,0 +1,124 @@
+# ===========================================================
+# Test: duckdb_datetime_zero_date
+# Description:
+#   Regression test for GitHub issue#131.
+#   Inserting an invalid integer (e.g. 57399) into a DATETIME
+#   column on a DuckDB engine table used to crash the server
+#   due to an assertion failure in sec_since_epoch() when
+#   month=0 (zero date).
+#
+#   This test verifies that DuckDB and InnoDB produce
+#   identical results for various invalid/zero-date INSERT
+#   scenarios.
+#
+# Tested feature: DuckDB DATETIME zero-date handling
+# Related source: storage/duckdb/delta_appender.cc
+# ===========================================================
+
+--echo #
+--echo # Setup
+--echo #
+--write_file $MYSQL_TMP_DIR/init_datetime_test.inc
+  --disable_warnings
+  DROP TABLE IF EXISTS t_duckdb, t_innodb;
+  --enable_warnings
+  CREATE TABLE t_duckdb (
+    id INT NOT NULL AUTO_INCREMENT,
+    col1 DATETIME NULL DEFAULT '2026-01-01 00:00:00',
+    PRIMARY KEY (id)
+  ) ENGINE=DuckDB;
+
+  CREATE TABLE t_innodb (
+    id INT NOT NULL AUTO_INCREMENT,
+    col1 DATETIME NULL DEFAULT '2026-01-01 00:00:00',
+    PRIMARY KEY (id)
+  ) ENGINE=InnoDB;
+EOF
+
+--write_file $MYSQL_TMP_DIR/check_duckdb_datetime.inc
+  SELECT * FROM t_duckdb ORDER BY id;
+  SELECT * FROM t_innodb ORDER BY id;
+
+  --let $checksum_t_innodb = query_get_value(CHECKSUM TABLE t_innodb, Checksum, 1)
+  --let $checksum_t_duckdb = query_get_value(CHECKSUM TABLE t_duckdb, Checksum, 1)
+  --let $assert_cond= $checksum_t_innodb = $checksum_t_duckdb
+  --let $assert_text= Checksum is the same
+  --source include/assert.inc
+EOF
+
+
+--echo # =========================================================
+--echo # Scenario 1: INSERT with invalid integer (57399)
+--echo #   This is the original crash case from GitHub issue#131.
+--echo # =========================================================
+--source $MYSQL_TMP_DIR/init_datetime_test.inc
+
+INSERT IGNORE INTO t_duckdb (id, col1) VALUES (1, 57399);
+INSERT IGNORE INTO t_innodb (id, col1) VALUES (1, 57399);
+
+--error ER_TRUNCATED_WRONG_VALUE
+INSERT INTO t_duckdb (id, col1) VALUES (2, 57399);
+--error ER_TRUNCATED_WRONG_VALUE
+INSERT INTO t_innodb (id, col1) VALUES (2, 57399);
+
+SET @saved_sql_mode = @@SESSION.sql_mode;
+SET sql_mode = '';
+INSERT INTO t_duckdb (id, col1) VALUES (2, 57399);
+INSERT INTO t_innodb (id, col1) VALUES (2, 57399);
+SET sql_mode = @saved_sql_mode;
+
+--source $MYSQL_TMP_DIR/check_duckdb_datetime.inc
+--echo # Scenario 1 PASSED: checksums match
+
+
+--echo # ==================================================
+--echo # Scenario 2: INSERT with various invalid integers
+--echo # ==================================================
+--source $MYSQL_TMP_DIR/init_datetime_test.inc
+
+# 0: zero value
+# 101: boundary (min valid YYMMDD-like is 101 -> 2000-01-01)
+# 99: below minimum valid
+# 57399: invalid month=73
+# 13320199: invalid day=99
+# -1: negative value
+INSERT IGNORE INTO t_duckdb (id, col1) VALUES
+  (1, 0), (2, 99), (3, 101), (4, 57399), (5, 13320199), (6, -1);
+INSERT IGNORE INTO t_innodb (id, col1) VALUES
+  (1, 0), (2, 99), (3, 101), (4, 57399), (5, 13320199), (6, -1);
+
+--source $MYSQL_TMP_DIR/check_duckdb_datetime.inc
+--echo # Scenario 2 PASSED: checksums match
+
+
+--echo # =========================================================
+--echo # Scenario 3: INSERT with mixing valid and invalid values
+--echo # =========================================================
+--source $MYSQL_TMP_DIR/init_datetime_test.inc
+
+INSERT IGNORE INTO t_duckdb (id, col1) VALUES
+  (1, '2026-06-15 10:30:00'),
+  (2, 57399),
+  (3, '2020-01-01 00:00:00'),
+  (4, 0),
+  (5, 20240615103000),
+  (6, NULL),
+  (7, '0000-00-00 00:00:00');
+INSERT IGNORE INTO t_innodb (id, col1) VALUES
+  (1, '2026-06-15 10:30:00'),
+  (2, 57399),
+  (3, '2020-01-01 00:00:00'),
+  (4, 0),
+  (5, 20240615103000),
+  (6, NULL),
+  (7, '0000-00-00 00:00:00');
+
+--source $MYSQL_TMP_DIR/check_duckdb_datetime.inc
+--echo # Scenario 3 PASSED: checksums match
+
+--echo #
+--echo # Cleanup
+--echo #
+DROP TABLE t_duckdb, t_innodb;
+--remove_file $MYSQL_TMP_DIR/init_datetime_test.inc
+--remove_file $MYSQL_TMP_DIR/check_duckdb_datetime.inc

--- a/storage/duckdb/delta_appender.cc
+++ b/storage/duckdb/delta_appender.cc
@@ -490,12 +490,28 @@ int DeltaAppender::append_mysql_field(const Field *field,
 
     case MYSQL_TYPE_DATETIME2: {
       MYSQL_TIME tm;
-      static_cast<const Field_datetimef *>(field)->get_date(&tm, TIME_FUZZY_DATE);
-      bool not_used;
-      longlong sec = my_tz_UTC->TIME_to_gmt_sec(&tm, &not_used);
-      // write_batch_longlong(col_index, &value);
+      static_cast<const Field_datetimef *>(field)->get_date(&tm,
+                                                            TIME_FUZZY_DATE);
+      longlong ts_us;
+      if (tm.month == 0) {
+        /*
+          Zero date (e.g. 0000-00-00 00:00:00) or invalid date with month=0.
+          Bypass TIME_to_gmt_sec() which asserts month > 0.
+          Use calc_daynr() to compute timestamp directly, consistent with
+          MYSQL_TYPE_NEWDATE handling.
+        */
+        long days =
+            calc_daynr(tm.year, tm.month, tm.day) - myduck::days_at_timestart;
+        ts_us = static_cast<longlong>(days) * 86400LL * 1000000LL +
+                tm.hour * 3600LL * 1000000LL + tm.minute * 60LL * 1000000LL +
+                tm.second * 1000000LL + tm.second_part;
+      } else {
+        bool not_used;
+        longlong sec = my_tz_UTC->TIME_to_gmt_sec(&tm, &not_used);
+        ts_us = sec * 1000000LL + tm.second_part;
+      }
       appender->Append<duckdb::timestamp_t>(
-          static_cast<duckdb::timestamp_t>(sec * 1000000 + tm.second_part));
+          static_cast<duckdb::timestamp_t>(ts_us));
       break;
     }
 


### PR DESCRIPTION
Fixes #131

Description
===========
- Server crashes with assertion failure when executing: INSERT IGNORE INTO t (col1) VALUES (57399) where col1 is a DATETIME column on a DuckDB engine table.
- The assertion `mon > 0 && mon < 13 && year <= 9999` in sec_since_epoch() (sql/tztime.cc:356) fails because the MYSQL_TIME struct contains month=0.
- InnoDB handles this case gracefully by truncating to zero date with a warning, but DuckDB engine crashes.

Cause
=====
- MySQL's SQL layer converts the invalid integer 57399 to a zero date (0000-00-00 00:00:00) via number_to_datetime() -> reset(), setting month=0.
- In the DuckDB write path, DeltaAppender::append_mysql_field() for MYSQL_TYPE_DATETIME2 calls TIME_to_gmt_sec() without validating the MYSQL_TIME struct, which triggers the assertion in sec_since_epoch().

Fix
===
- Add a zero/invalid date check (tm.month == 0) in the MYSQL_TYPE_DATETIME2 branch of DeltaAppender::append_mysql_field() before calling TIME_to_gmt_sec().
- When a zero date is detected, compute the timestamp directly using calc_daynr(), consistent with the existing MYSQL_TYPE_NEWDATE handling.
- Valid dates (month in [1, 12]) continue to use the original TIME_to_gmt_sec() path.