### PR TITLE
Fix JSON function error handling when called from DuckDB engine

### DIFF
--- a/sql-common/json_error_handler.cc
+++ b/sql-common/json_error_handler.cc
@@ -29,10 +29,17 @@
 
 void JsonParseDefaultErrorHandler::operator()(const char *parse_err,
                                               size_t err_offset) const {
+  if (m_caller_is_duckdb) {
+    throw std::exception();
+  }
   my_error(ER_INVALID_JSON_TEXT_IN_PARAM, MYF(0), m_arg_idx + 1, m_func_name,
            parse_err, err_offset, "");
 }
 
 void JsonDocumentDefaultDepthHandler() {
   my_error(ER_JSON_DOCUMENT_TOO_DEEP, MYF(0));
+}
+
+void JsonDocumentDefaultDepthHandlerDuckDB() {
+  throw std::exception();
 }

--- a/sql-common/json_error_handler.h
+++ b/sql-common/json_error_handler.h
@@ -39,6 +39,7 @@ class JsonParseDefaultErrorHandler {
       : m_func_name(func_name), m_arg_idx(arg_idx) {}
 
   void operator()(const char *parse_err, size_t err_offset) const;
+  bool m_caller_is_duckdb = false;
 
  private:
   const char *m_func_name;
@@ -46,6 +47,7 @@ class JsonParseDefaultErrorHandler {
 };
 
 void JsonDocumentDefaultDepthHandler();
+void JsonDocumentDefaultDepthHandlerDuckDB();
 
 #endif  // MYSQL_SERVER
 #endif  // JSON_ERROR_HANDLER_INCLUDED

--- a/sql/duckdb/duckdb_mysql_udf.cc
+++ b/sql/duckdb/duckdb_mysql_udf.cc
@@ -51,6 +51,7 @@ bool mysql_json_overlaps(duckdb::string_t json1, duckdb::string_t json2) {
   Item_duckdb_string item_json1(json1);
   Item_duckdb_string item_json2(json2);
   Item_func_json_overlaps json_overlaps(POS(), &item_json1, &item_json2);
+  json_overlaps.m_caller_is_duckdb = true;
   json_overlaps.fixed = true;
   return json_overlaps.val_int();
 }
@@ -59,6 +60,7 @@ int64_t mysql_json_depth(duckdb::string_t json) {
   Item_duckdb_string item_json(json);
   Item_func_json_depth json_depth(POS(), &item_json);
   json_depth.fixed = true;
+  json_depth.m_caller_is_duckdb = true;
   return json_depth.val_int();
 }
 
@@ -80,6 +82,7 @@ void mysql_json_unquote(duckdb::DataChunk &input,
       Item_duckdb_string item_json(*ldata);
       Item_func_json_unquote json_unquote(POS(), &item_json);
       json_unquote.fixed = true;
+      json_unquote.m_caller_is_duckdb = true;
       String tmp;
       String *func_result = json_unquote.val_str(&tmp);
       if (json_unquote.null_value) {
@@ -109,6 +112,7 @@ void mysql_json_unquote(duckdb::DataChunk &input,
       Item_duckdb_string item_json(data[i]);
       Item_func_json_unquote json_unquote(POS(), &item_json);
       json_unquote.fixed = true;
+      json_unquote.m_caller_is_duckdb = true;
       String tmp;
       String *func_result = json_unquote.val_str(&tmp);
       if (json_unquote.null_value) {

--- a/sql/item_json_func.cc
+++ b/sql/item_json_func.cc
@@ -73,6 +73,7 @@
 #include "sql/thd_raii.h"
 #include "sql/thr_malloc.h"
 #include "template_utils.h"  // down_cast
+#include "duckdb/common/exception.hpp"
 
 class PT_item_list;
 
@@ -304,7 +305,8 @@ static bool check_convertible_to_json(const Item *item, int argument_number,
 */
 static bool json_is_valid(Item **args, uint arg_idx, String *value,
                           const char *func_name, Json_dom_ptr *dom,
-                          bool require_str_or_json, bool *valid) {
+                          bool require_str_or_json, bool *valid,
+                          bool caller_is_duckdb = false) {
   Item *const arg_item = args[arg_idx];
 
   enum_field_types field_type = get_normalized_field_type(arg_item);
@@ -312,6 +314,9 @@ static bool json_is_valid(Item **args, uint arg_idx, String *value,
   if (!is_convertible_to_json(arg_item)) {
     if (require_str_or_json) {
       *valid = false;
+      if (caller_is_duckdb) {
+        throw duckdb::InvalidInputException("Invalid input in json func");
+      }
       my_error(ER_INVALID_TYPE_FOR_JSON, MYF(0), arg_idx + 1, func_name);
       return true;
     }
@@ -330,7 +335,9 @@ static bool json_is_valid(Item **args, uint arg_idx, String *value,
     return !*valid;
   } else {
     String *const res = arg_item->val_str(value);
-    if (current_thd->is_error()) return true;
+    if (!caller_is_duckdb) {
+      if (current_thd->is_error()) return true;
+    }
 
     if (arg_item->null_value) {
       *valid = true;
@@ -340,8 +347,11 @@ static bool json_is_valid(Item **args, uint arg_idx, String *value,
     bool parse_error = false;
     const bool failure = parse_json(
         *res, dom, require_str_or_json,
-        [&parse_error, arg_idx, func_name](const char *parse_err,
-                                           size_t err_offset) {
+        [&parse_error, arg_idx, func_name, caller_is_duckdb](
+            const char *parse_err, size_t err_offset) {
+          if (caller_is_duckdb) {
+            throw duckdb::InvalidInputException("Invalid input in json func");
+          }
           my_error(ER_INVALID_JSON_TEXT_IN_PARAM, MYF(0), arg_idx + 1,
                    func_name, parse_err, err_offset, "");
           parse_error = true;
@@ -1084,7 +1094,8 @@ bool json_value(Item *arg, Json_wrapper *result, bool *has_value) {
 }
 
 bool get_json_wrapper(Item **args, uint arg_idx, String *str,
-                      const char *func_name, Json_wrapper *wrapper) {
+                      const char *func_name, Json_wrapper *wrapper,
+                      bool caller_is_duckdb) {
   Item *const arg = args[arg_idx];
 
   bool has_value;
@@ -1104,10 +1115,14 @@ bool get_json_wrapper(Item **args, uint arg_idx, String *str,
   Json_dom_ptr dom;  //@< we'll receive a DOM here from a successful text parse
 
   bool valid;
-  if (json_is_valid(args, arg_idx, str, func_name, &dom, true, &valid))
+  if (json_is_valid(args, arg_idx, str, func_name, &dom, true, &valid,
+                    caller_is_duckdb))
     return true;
 
   if (!valid) {
+    if (caller_is_duckdb) {
+      throw duckdb::InvalidInputException("Invalid input in json func");
+    }
     my_error(ER_INVALID_TYPE_FOR_JSON, MYF(0), arg_idx + 1, func_name);
     return true;
   }
@@ -1743,10 +1758,13 @@ longlong Item_func_json_depth::val_int() {
   Json_wrapper wrapper;
 
   try {
-    if (get_json_wrapper(args, 0, &m_doc_value, func_name(), &wrapper))
+    if (get_json_wrapper(args, 0, &m_doc_value, func_name(), &wrapper, m_caller_is_duckdb))
       return error_int();
   } catch (...) {
     /* purecov: begin inspected */
+    if (m_caller_is_duckdb) {
+      throw duckdb::InvalidInputException("Invalid input in json func");
+    }
     handle_std_exception(func_name());
     return error_int();
     /* purecov: end */
@@ -3249,7 +3267,7 @@ String *Item_func_json_unquote::val_str(String *str) {
   try {
     if (args[0]->data_type() == MYSQL_TYPE_JSON) {
       Json_wrapper wr;
-      if (get_json_wrapper(args, 0, str, func_name(), &wr)) {
+      if (get_json_wrapper(args, 0, str, func_name(), &wr, m_caller_is_duckdb)) {
         return error_str();
       }
 
@@ -3260,8 +3278,13 @@ String *Item_func_json_unquote::val_str(String *str) {
 
       m_value.length(0);
 
-      if (wr.to_string(&m_value, false, func_name(),
-                       JsonDocumentDefaultDepthHandler)) {
+      if (m_caller_is_duckdb) {
+        if (wr.to_string(&m_value, false, func_name(),
+                         JsonDocumentDefaultDepthHandlerDuckDB)) {
+          return error_str();
+        }
+      } else if (wr.to_string(&m_value, false, func_name(),
+                              JsonDocumentDefaultDepthHandler)) {
         return error_str();
       }
 
@@ -3317,6 +3340,7 @@ String *Item_func_json_unquote::val_str(String *str) {
 
     Json_dom_ptr dom;
     JsonParseDefaultErrorHandler parse_handler(func_name(), 0);
+    parse_handler.m_caller_is_duckdb = m_caller_is_duckdb;
     if (parse_json(*utf8str, &dom, true, parse_handler,
                    JsonDocumentDefaultDepthHandler)) {
       return error_str();
@@ -3331,6 +3355,9 @@ String *Item_func_json_unquote::val_str(String *str) {
       return error_str(); /* purecov: inspected */
   } catch (...) {
     /* purecov: begin inspected */
+    if (m_caller_is_duckdb) {
+      throw duckdb::InvalidInputException("Invalid input in json func");
+    }
     handle_std_exception(func_name());
     return error_str();
     /* purecov: end */
@@ -3857,14 +3884,16 @@ longlong Item_func_json_overlaps::val_int() {
     Json_wrapper *doc_b = &wr_b;
 
     // arg 0 is the document 1
-    if (get_json_wrapper(args, 0, &m_doc_value, func_name(), doc_a) ||
+    if (get_json_wrapper(args, 0, &m_doc_value, func_name(), doc_a,
+                         m_caller_is_duckdb) ||
         args[0]->null_value) {
       null_value = true;
       return 0;
     }
 
     // arg 1 is the document 2
-    if (get_json_wrapper(args, 1, &m_doc_value, func_name(), doc_b) ||
+    if (get_json_wrapper(args, 1, &m_doc_value, func_name(), doc_b,
+                         m_caller_is_duckdb) ||
         args[1]->null_value) {
       null_value = true;
       return 0;
@@ -3913,6 +3942,9 @@ longlong Item_func_json_overlaps::val_int() {
     }
     /* purecov: begin inspected */
   } catch (...) {
+    if (m_caller_is_duckdb) {
+      throw duckdb::InvalidInputException("Invalid invalid in json func");
+    }
     handle_std_exception(func_name());
     return error_int();
     /* purecov: end */

--- a/sql/item_json_func.h
+++ b/sql/item_json_func.h
@@ -250,10 +250,12 @@ bool json_value(Item *arg, Json_wrapper *result, bool *has_value);
   @param[out] str           the string buffer
   @param[in]  func_name     the name of the function we are executing
   @param[out] wrapper       the JSON value wrapper
+  @param[in] caller_is_duckdb       the func caller is duckdb
   @returns false if we found a value or NULL, true if not.
 */
 bool get_json_wrapper(Item **args, uint arg_idx, String *str,
-                      const char *func_name, Json_wrapper *wrapper);
+                      const char *func_name, Json_wrapper *wrapper,
+                      bool caller_is_duckdb = false);
 
 /**
   Convert Json values or MySQL values to JSON.
@@ -534,6 +536,7 @@ class Item_func_json_depth final : public Item_int_func {
   }
 
   longlong val_int() override;
+  bool m_caller_is_duckdb = false;
 };
 
 /**
@@ -915,6 +918,7 @@ class Item_func_json_unquote : public Item_str_func {
   }
 
   String *val_str(String *str) override;
+  bool m_caller_is_duckdb = false;
 };
 
 /**
@@ -1054,6 +1058,7 @@ class Item_func_json_overlaps : public Item_bool_func {
   enum_const_item_cache can_cache_json_arg(Item *arg) override {
     return (arg == args[0] || arg == args[1]) ? CACHE_JSON_VALUE : CACHE_NONE;
   }
+  bool m_caller_is_duckdb = false;
 };
 
 class Item_func_member_of : public Item_bool_func {


### PR DESCRIPTION
When JSON functions (json_overlaps, json_depth, json_unquote) are called from DuckDB engine with invalid input, they previously triggered MySQL error handling (my_error) which is not appropriate in the DuckDB context.

This fix adds a `m_caller_is_duckdb` flag to the relevant JSON function classes so that when called from DuckDB, errors are thrown as C++ exceptions (duckdb::InvalidInputException) instead of MySQL errors, allowing DuckDB to handle them properly.

Fixes alibaba/AliSQL#136